### PR TITLE
feat: add readme instructions to run local version of ethereum-react-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,42 @@ This project is a "fork" / re-write of ethereum/Mist's user interface
 It is bootstrapped with [Create React App v2](https://github.com/facebookincubator/create-react-app), is 100% written in React and removes the meteor framework dependency.
 
 ### Project Goals
+
 - improved security and easier maintenance
 - rapid development, faster iterations and releases
 - improved testability
 - removal of electron API references from UI components
-- allows to run the app in a browser, electron or [tau](https://github.com/PhilippLgh/tau) window 
+- allows to run the app in a browser, electron or [tau](https://github.com/PhilippLgh/tau) window
 - separation of electron shell application and user interface
-- independant release, versioning and packaging of host application (Mist) and dapp (MistUI, WalletUI)
+- independent release, versioning and packaging of host application (Mist) and dapp (MistUI, WalletUI)
 - introduction of an app namespace and removal of global variables
 - reducing the amount of custom build scripts required to produce distributables
 - a popular technology to encourage the community to contribute
 - no network connection or full node required to run and develop the UI
 
 ### Run
+
 ```
 if not installed:
 npm install -g less
 
-git clone https://github.com/ethereum/mist-ui-react.git
-cd mist-ui-react
+git clone https://github.com/ethereum/mist-ui.git
+cd mist-ui
 yarn
 
 Start in 3 terminals:
 yarn run watch-css  -> compile less to css and watch for changes (less + react compat workaround)
-yarn run start -> start dev server for react with hot relaoding
+yarn run start -> start dev server for react with hot reloading
 yarn run electron:dev -> load the app from the dev server into an electron window
 ```
+
+#### Using local ethereum-react-components
+
+To develop in `mist-ui` using your local copy of `ethereum-react-components`:
+
+1. cd `ethereum-react-components`
+1. `npm link`
+1. cd `mist-ui`
+1. `npm link ethereum-react-components`
+
+After making changes in `ethereum-react-components`, run `yarn` for a fresh build to be picked up by `mist-ui`.


### PR DESCRIPTION
This PR adds instructions to the bottom of `README.md` with instructions on how to use a local copy of ethereum-react-components in dev.