### PR TITLE
fix: hide out of scope features

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,15 +11,6 @@ export default class App extends Component {
   render() {
     const items = [
       {
-        id: 0,
-        name: 'Wallet',
-        route: 'wallet',
-        subitems: [
-          { id: '0a', name: 'Create Account', route: 'account/create' },
-          { id: '0b', name: 'Import Account', route: 'account/import' }
-        ]
-      },
-      {
         id: 1,
         name: 'Tx',
         route: 'tx',
@@ -47,14 +38,9 @@ export default class App extends Component {
           { id: '3b', name: 'Geth Setup', route: 'network/nodesetup' },
           { id: '3c', name: 'Geth Config', route: 'network/nodeconfig' }
         ]
-      },
-      {
-        id: 4,
-        name: 'Browser',
-        route: 'browser',
-        subitems: [{ id: '4a', name: 'Browser', route: 'browser' }]
       }
-
+      // {id: 0, name: 'Wallet', route: 'wallet', subitems: [ { id: '0a', name: 'Create Account', route: 'account/create' }, { id: '0b', name: 'Import Account', route: 'account/import' } ]},
+      // {id: 4, name: 'Browser', route: 'browser', subitems: [{ id: '4a', name: 'Browser', route: 'browser' }]},
       // {id: 5, name: 'dapps', icon: 'https://cdn4.iconfinder.com/data/icons/web-mobile-round1/210/Untitled-35-512.png', route: `dapps`},
       // {id: 6, name: 'contracts', icon: 'https://cdn2.iconfinder.com/data/icons/business-finance-line-1/24/Contract-512.png'},
       // {id: 7, name: 'remix', icon: 'https://raw.githubusercontent.com/horizon-games/remix-app/master/resources/icon.png', route: `browser/${encodeURIComponent('https://remix.ethereum.org/')}`},

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -26,7 +26,7 @@ export default function Routes() {
     <Switch>
       {window.location.href.endsWith('index.html') && <Redirect to="/" />}
 
-      <Route path="/" exact component={Wallet} />
+      <Route path="/" exact component={NodeSetup} />
       <Route path="/wallet" exact component={Wallet} />
       <Route path="/account/create" exact component={CreateAccount} />
       <Route path="/tx" exact component={Wallet} />

--- a/src/components/SidebarTab.js
+++ b/src/components/SidebarTab.js
@@ -14,7 +14,6 @@ class SidebarTab extends Component {
 
   constructor(props) {
     super(props)
-    this.handleConnectBtnClick = this.handleConnectBtnClick.bind(this)
 
     // query connected accounts for this dapp
     const dappAccounts = []

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import { BrowserRouter as Router } from 'react-router-dom'
 import App from './App'
 import Popup from './Popup'
-import { Mist } from './API'
+// import { Mist } from './API'
 import store from './API/ReduxStore'
 
 // see https://github.com/facebook/create-react-app/issues/1084#issuecomment-273272872
@@ -30,7 +30,7 @@ const root = document.getElementById('root')
 const urlParams = getUrlVars()
 const popupName = urlParams.name
 
-const args = Mist.window.getArgs()
+const args = null // Mist.window.getArgs()
 switch (urlParams.app) {
   case 'popup':
     store.dispatch({


### PR DESCRIPTION
#### What does it do?
- removes `Wallet` and `Browser` navigation tabs
- sets `NodeSetup` as root route
- temporarily resolves breaking bug on load
#### Any helpful background information?
Re: breaking bug, `Mist.window` is undefined, so `Mist.window.getArgs()` breaks on line 33 of `src/index.js`. The preload file in `mist-shell` only passes along a `geth` key on the `Mist` window object.