### PR TITLE
fix: adds contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ It is bootstrapped with [Create React App v2](https://github.com/facebookincubat
 - a popular technology to encourage the community to contribute
 - no network connection or full node required to run and develop the UI
 
-### Run
+### Contributing
+
+There are many ways to get involved with this project. Get started [here](/docs/CONTRIBUTING.md).
+
+### Development
 
 ```
 if not installed:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+## Contributing to Mist
+
+First, thanks for your interest! We appreciate your time.
+
+#### Some background
+
+Mist is undergoing a large refactoring/rewrite. The project has been broken into several pieces:
+
+- [ethereum-react-components](https://github.com/ethereum/ethereum-react-components) - a React component library
+- mist-ui (this repo) - uses the component library to assemble Mist's user interface
+- [mist-shell](https://github.com/ethereum/mist-shell) - the desktop app wrapper for mist-ui
+- [electron-app-manager](https://github.com/PhilippLgh/electron-app-manager) - handles app updates
+
+The MVP will be a node management tool for power users. No wallet or browser features will be included in the first release. Proposed MVP release date: first week of March 2019.
+
+#### How can I contribute?
+
+- Answer/contribute to other user's open issues.
+- Report a bug by opening a GitHub issue.
+- Suggest an enhancement by opening a GitHub issue.
+- Contribute to documentation by opening a pull request.
+- Fix a bug or add a feature by opening a pull request.
+  - Looking for something to work on? Try filtering for [good first issue](https://github.com/ethereum/mist-ui/labels/good%20first%20issue) tags.
+
+#### Adding new features
+
+Before spending the time on a new feature that isn't already requested in an issue, please open a new issue to suggest the enhancement. The Mist team will let you know whether the proposed feature fits into our broader vision.
+
+#### Reporting bugs
+
+Before filing, please search for related issues and contribute to existing discussions if appropriate. If no bug resembles yours, do your best to fill out the new issue template, including detailed steps to reproduce the issue.
+
+#### Pull Requests
+
+- Please fill out the PR template! Your answers will help us review and merge your code more quickly.
+- Use your linter! If your editor isn't configured with eslint, run it in a terminal window with `yarn lint:watch` or `npm run lint:watch`.
+- Use [conventional commits](https://www.conventionalcommits.org/) to help us evaluate semantic versioning needs, e.g. `fix:`, `feat:`, `docs:`, etc. commit prefixes.
+- [Reference related issues](https://help.github.com/articles/closing-issues-using-keywords/) when appropriate, e.g. "Closes #13" in a PR description.


### PR DESCRIPTION
#### What does it do?
Introduces some contribution context/guidelines. Closes https://github.com/ethereum/mist-shell/issues/41.
#### Any helpful background information?
This [template](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md) was helpful in coming up with ideas.