### PR TITLE
fix: bootup with or without mist-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bignumber.js": "^7.2.1",
     "bn.js": "^4.11.8",
     "dapp-styles": "git+https://github.com/ethereum/dapp-styles.git",
-    "ethereum-react-components": "^1.11.2",
+    "ethereum-react-components": "^1.12.0",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "numeral": "^2.0.6",

--- a/src/API/Mist.js
+++ b/src/API/Mist.js
@@ -14,7 +14,15 @@ const { _mist } = window
 // let Ganache = new Web3.providers.HttpProvider("HTTP://127.0.0.1:7545")
 // var web3 = new Web3(Ganache);
 
-const MistApi = {
+let MistApi = {
+  geth: {
+    getLocalBinaries: () => {
+      return []
+    },
+    getReleases: () => {
+      return []
+    }
+  },
   requestAccount: () => {
     // window.mist.requestAccount
   },
@@ -82,5 +90,9 @@ const MistApi = {
   }
 }
 
-// export default MistApi
-export default window.Mist
+// window.Mist is made available by mist-shell
+if (window.Mist) {
+  MistApi = window.Mist
+}
+
+export default MistApi

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux'
 import { BrowserRouter as Router } from 'react-router-dom'
 import App from './App'
 import Popup from './Popup'
-// import { Mist } from './API'
+import { Mist } from './API'
 import store from './API/ReduxStore'
 
 // see https://github.com/facebook/create-react-app/issues/1084#issuecomment-273272872
@@ -30,7 +30,7 @@ const root = document.getElementById('root')
 const urlParams = getUrlVars()
 const popupName = urlParams.name
 
-const args = null // Mist.window.getArgs()
+const args = Mist.getWindowArgs()
 switch (urlParams.app) {
   case 'popup':
     store.dispatch({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3754,10 +3754,10 @@ ethereum-common@^0.0.18:
   resolved "https://registry.yarnpkg.com/ethereum-common/-/ethereum-common-0.0.18.tgz#2fdc3576f232903358976eb39da783213ff9523f"
   integrity sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=
 
-ethereum-react-components@^1.11.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/ethereum-react-components/-/ethereum-react-components-1.11.2.tgz#813c5010d4e2f664685ca72428b0049fad162a53"
-  integrity sha512-Hokwu0MvIGyzxACgj8wVDPdIDA81VPYaFT/RIYnUNuEJFs7/ScxzdU2P3bVSe8WEXNZptOv+rM//yuGHGmD+5A==
+ethereum-react-components@^1.12.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/ethereum-react-components/-/ethereum-react-components-1.12.1.tgz#fbad07a7893c78aeef4a8b80665cf590516512c9"
+  integrity sha512-EsgTDzOPFIIMLe/YQIkswdkiZ0ScmRcbaEM8gjB3miMzJDIjOQBty8ypHorW6SMW735DgAo2KA2C1Pkb8TR7gA==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^1.2.9"
     "@fortawesome/free-solid-svg-icons" "^5.6.0"


### PR DESCRIPTION
#### What does it do?
- Slightly better hot fix for running the app locally, with or without mist-shell.
- Bumps component lib version.
#### Any helpful background information?
- When testing with `mist-shell`: `window.Mist` is made available by the preload file, `mist-ui` uses that API. (Depends on PR in mist-shell: https://github.com/ethereum/mist-shell/pull/42.)
- When testing with only `mist-ui`: no `window.Mist` is available, so mock API is returned instead.